### PR TITLE
Custom attributes

### DIFF
--- a/features/step_definitions/watir_ng_steps.rb
+++ b/features/step_definitions/watir_ng_steps.rb
@@ -1,24 +1,32 @@
-Given /^I've navigated to a web page$/ do
+Given /^an element exists on a web page$/ do
   @browser.goto "https://docs.angularjs.org/guide/directive"
 end
 
-Given /^I register a custom directive with WatirNg$/ do
-  WatirNg.custom_directives << :ng_foo
+Given /^an element does not exist on a web page$/ do
+  @browser.goto "http://www.google.com"
 end
 
-When /^I identify an element with a "(.*)" of "(.*)"$/ do |locator, value|
-  @element = @browser.element(locator.to_sym => value)
+When /^I use a (standard|directive) identifier to find it$/ do |id|
+  elements = {
+    "standard"  => {
+      "element" => :h2,
+      "identifier" => { id: "creating-directives" }
+    },
+    "directive" => {
+      "element" => :div,
+      "identifier" => { ng_show: "loading" }
+    }
+  }
+  
+  @element = @browser.send(elements[id]["element"], elements[id]["identifier"])
 end
 
-Then /^I found the "(.*)"$/ do |html|
-  expect(@element.tag_name).to eq html
+Then /^the element is located$/ do
+  expect(@element).to exist
 end
 
-Then /^the element is missing$/ do
-  expect(@element.present?).to be false
+Then /^the element is not found$/ do
+  expect(@element).to_not exist
 end
 
-Then /^no error is raised$/ do
-  expect{ @element.exist? }.to_not raise_error
-end
 

--- a/features/step_definitions/watir_ng_steps.rb
+++ b/features/step_definitions/watir_ng_steps.rb
@@ -1,22 +1,9 @@
-# Given /^I am using a WebDriver instance patched with WatirNg$/ do
-#   @browser = Watir::Browser.new
-# end
-
-# Given /^I have navigated to "(.*)"$/ do |url|
-#   @browser.goto url
-# end
-
-# When /^I identify a "(.*)" element with an "(.*)" of "(.*)"$/ do |tag, ng, value|
-#   identifier = { ng.to_sym => value }
-#   @element = @browser.send(tag, identifier)
-# end
-
-# Then /^my WebDriver instance reports the element (\w+)$/ do |expectation|
-#   expectation == "present" ? @element.present? : !@element.present?
-# end
-
 Given /^I've navigated to a web page$/ do
   @browser.goto "https://docs.angularjs.org/guide/directive"
+end
+
+Given /^I register a custom directive with WatirNg$/ do
+  WatirNg.custom_directives << :ng_foo
 end
 
 When /^I identify an element with a "(.*)" of "(.*)"$/ do |locator, value|
@@ -29,5 +16,9 @@ end
 
 Then /^the element is missing$/ do
   expect(@element.present?).to be false
+end
+
+Then /^no error is raised$/ do
+  expect{ @element.exist? }.to_not raise_error
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 require 'watir-ng'
 
-Before do
+Before('~@configuration') do
+  @browser = Watir::Browser.new
+end
+
+Before('@configuration') do
+  WatirNg.custom_directives << :ng_foo
   @browser = Watir::Browser.new
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,15 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 require 'watir-ng'
 
-Before('~@configuration') do
-  @browser = Watir::Browser.new
-end
-
-Before('@configuration') do
-  WatirNg.custom_directives << :ng_foo
-  @browser = Watir::Browser.new
-end
-
-After do
-  @browser.close
-end
+Before { @browser = Watir::Browser.new }
+After  { @browser.close }

--- a/features/watir_ng.feature
+++ b/features/watir_ng.feature
@@ -23,3 +23,9 @@ Feature: Identifying HTML elements with ng directives
     | ng_click   | bar   |
     | id         | fizz  |
     | class      | buzz  |
+
+  @configuration
+  Scenario: Identifying a custom directive
+    Given I register a custom directive with WatirNg
+    When I identify an element with a "ng_foo" of "bar"
+    Then no error is raised

--- a/features/watir_ng.feature
+++ b/features/watir_ng.feature
@@ -1,31 +1,21 @@
 Feature: Identifying HTML elements with ng directives
 
-  Background:
-    Given I've navigated to a web page
-    
-  Scenario Outline: Identifying existing elements
-    When I identify an element with a "<identifier>" of "<value>"
-    Then I found the "<element>"
-    
-    Examples:
-    | identifier | value               | element |
-    | ng_include | partialPath         | div     |
-    | id         | creating-directives | h2      |
-    | ng_show    | loading             | div     |
+  Scenario: Locating HTML elements with standard identifiers
+    Given an element exists on a web page
+    When I use a standard identifier to find it
+    Then the element is located
 
-  Scenario Outline: Identifying non-existent elements
-    When I identify an element with a "<identifier>" of "<value>"
-    Then the element is missing
-    
-    Examples:
-    | identifier | value |
-    | ng_focus   | foo   |
-    | ng_click   | bar   |
-    | id         | fizz  |
-    | class      | buzz  |
+  Scenario: Locating HTML elements with ng directives
+    Given an element exists on a web page
+    When I use a directive identifier to find it
+    Then the element is located
 
-  @configuration
-  Scenario: Identifying a custom directive
-    Given I register a custom directive with WatirNg
-    When I identify an element with a "ng_foo" of "bar"
-    Then no error is raised
+  Scenario: Not locating HTML elements with standard identifiers
+    Given an element does not exist on a web page
+    When I use a standard identifier to find it
+    Then the element is not found
+
+  Scenario: Not locating HTML elements with ng directives
+    Given an element does not exist on a web page
+    When I use a directive identifier to find it
+    Then the element is not found

--- a/lib/watir-ng.rb
+++ b/lib/watir-ng.rb
@@ -22,14 +22,15 @@ module WatirNg
                  )
 
   #
-  # Inserts `NG_STRINGS` into `cls.attributes` as symbols when included in the class.
+  # Inserts `NG_STRINGS` and `custom_directives` into `cls.attributes` as symbols when
+  #  included in the class.
   #
   # @param cls [Class]
   # @return [nil]
   #
   def self.included cls
     if cls.respond_to? :attributes
-      ng_directives.each { |ng| cls.attributes << ng }
+      ng_directives.push(*custom_directives).each { |ng| cls.attributes << ng }
     end
   end
 
@@ -41,6 +42,15 @@ module WatirNg
   #
   def self.ng_directives
     @ng_directives ||= NG_STRINGS.map(&:to_sym)
+  end
+
+  #
+  # Collect custom defined directives.
+  #
+  # @return [Array]
+  #
+  def self.custom_directives
+    @custom_directives ||= []
   end
 end
 

--- a/spec/watir_ng_spec.rb
+++ b/spec/watir_ng_spec.rb
@@ -7,7 +7,13 @@ describe WatirNg do
     expect(WatirNg::VERSION).not_to be nil
   end
 
-  context "when included in a class" do
+  describe "#custom_directives" do
+    it "returns an array" do
+      expect(WatirNg.custom_directives).to eq []
+    end
+  end
+
+  context "when included on a class" do
     it "adds each ng directive to class.attributes" do
       TestClass.send(:include, WatirNg)
       expect(TestClass.attributes).to eq directives
@@ -16,7 +22,14 @@ describe WatirNg do
     it "does not overwrite the class.attributes" do
       TestClass.attributes = [:foo]
       TestClass.send(:include, WatirNg)
-      expect(TestClass.attributes).to eq [:foo] + directives
+      expect(TestClass.attributes).to include(:foo)
+      expect(TestClass.attributes).to include(*directives)
+    end
+
+    it "includes custom directives when configured" do
+      WatirNg.custom_directives << :ng_foo_bar
+      TestClass.send(:include, WatirNg)
+      expect(TestClass.attributes).to include(:ng_foo_bar)
     end
   end
 end


### PR DESCRIPTION
Adds feature to include custom attributes for element identification. Push a custom identifier onto `WatirNg.custom_directives` before instantiating the browser object.

``` ruby
require 'watir-webdriver'
require 'watir-ng'
WatirNg.custom_directives << :ng_foo_bar
@browser = Watir::Browser.new
```
