### PR TITLE
Fix #3

### DIFF
--- a/lib/watir-ng.rb
+++ b/lib/watir-ng.rb
@@ -1,4 +1,5 @@
 require "watir-webdriver"
+require "watir-ng/directives"
 require "watir-ng/version"
 
 #
@@ -6,51 +7,36 @@ require "watir-ng/version"
 #
 module WatirNg
 
-  #
-  # All the ng directives from the AngularJS documentation.
-  #
-  # @see `https://docs.angularjs.org/api/ng/directive`
-  #
-  NG_STRINGS = %w(ng_jq ng_app ng_href ng_src ng_srcset ng_disabled ng_checked ng_readonly 
-                  ng_selected ng_open ng_form ng_value ng_bind ng_bind_template ng_bind_html 
-                  ng_change ng_class ng_class_odd ng_class_even ng_cloak ng_controller ng_csp 
-                  ng_click ng_dblclick ng_mousedown ng_mouseup ng_mouseover ng_mouseenter 
-                  ng_mouseleave ng_mousemove ng_keydown ng_keyup ng_keypress ng_submit ng_focus
-                  ng_blur ng_copy ng_cut ng_paste ng_if ng_include ng_init ng_list ng_model 
-                  ng_model_options ng_non_bindable ng_options ng_pluralize ng_repeat ng_show 
-                  ng_hide ng_style ng_switch ng_transclude
-                 )
-
-  #
-  # Inserts `NG_STRINGS` and `custom_directives` into `cls.attributes` as symbols when
-  #  included in the class.
-  #
-  # @param cls [Class]
-  # @return [nil]
-  #
-  def self.included cls
-    if cls.respond_to? :attributes
-      ng_directives.push(*custom_directives).each { |ng| cls.attributes << ng }
+  class << self
+    
+    #
+    # Patch ng directives onto the array returned by `BaseClass.attributes`.
+    #
+    # @param cls [Class] base class
+    # @return [nil]
+    #
+    def included cls
+      cls.attributes.push *directives.ng
     end
-  end
 
-  #
-  # Converts `NG_STRINGS` into an array of symbols.
-  #
-  # @api private
-  # @return [Array<Symbol>] directives
-  #
-  def self.ng_directives
-    @ng_directives ||= NG_STRINGS.map(&:to_sym)
-  end
+    #
+    # Return directive collection object.
+    #
+    # @return [WatirNg::Directives]
+    #
+    def directives
+      @directives ||= Directives.new
+    end
 
-  #
-  # Collect custom defined directives.
-  #
-  # @return [Array]
-  #
-  def self.custom_directives
-    @custom_directives ||= []
+    #
+    # Register custom directives to be patched onto the base class attributes array.
+    #
+    # @param custom_directives [Symbol, String]
+    # @return [Array<Symbol>]
+    #
+    def register *custom_directives
+      directives.add custom_directives.map(&:to_sym)
+    end
   end
 end
 

--- a/lib/watir-ng.rb
+++ b/lib/watir-ng.rb
@@ -16,7 +16,7 @@ module WatirNg
     # @return [nil]
     #
     def included cls
-      cls.attributes.push *directives.ng
+      cls.attributes.push *directives.ng.map(&:to_sym)
     end
 
     #

--- a/lib/watir-ng/directives.rb
+++ b/lib/watir-ng/directives.rb
@@ -1,7 +1,7 @@
 module WatirNg
   class Directives
     def ng
-      %i(ng_jq ng_app ng_href ng_src ng_srcset ng_disabled ng_checked ng_readonly 
+      %w(ng_jq ng_app ng_href ng_src ng_srcset ng_disabled ng_checked ng_readonly 
          ng_selected ng_open ng_form ng_value ng_bind ng_bind_template ng_bind_html 
          ng_change ng_class ng_class_odd ng_class_even ng_cloak ng_controller ng_csp 
          ng_click ng_dblclick ng_mousedown ng_mouseup ng_mouseover ng_mouseenter 

--- a/lib/watir-ng/directives.rb
+++ b/lib/watir-ng/directives.rb
@@ -1,5 +1,15 @@
 module WatirNg
+  
+  #
+  # Object that stores ng directives and patches custom directives onto Watir::HTMLElement.
+  #
   class Directives
+    
+    #
+    # Returns array of ng directives.
+    #
+    # @return [Array<String>]
+    #
     def ng
       %w(ng_jq ng_app ng_href ng_src ng_srcset ng_disabled ng_checked ng_readonly 
          ng_selected ng_open ng_form ng_value ng_bind ng_bind_template ng_bind_html 
@@ -10,7 +20,15 @@ module WatirNg
          ng_model_options ng_non_bindable ng_options ng_pluralize ng_repeat ng_show 
          ng_hide ng_style ng_switch ng_transclude)
     end
-
+    
+    #
+    # Patches each element in an array onto `Watir::HTMLElement.attributes`.
+    #
+    # @param directives [Array] identifiers to be patched onto HTMLElement
+    # @return [Array]
+    #
+    # @see Watir::HTMLElement
+    #
     def add directives
       directives.tap do |array|
         array.each { |custom| Watir::HTMLElement.attributes << custom }

--- a/lib/watir-ng/directives.rb
+++ b/lib/watir-ng/directives.rb
@@ -1,0 +1,20 @@
+module WatirNg
+  class Directives
+    def ng
+      %i(ng_jq ng_app ng_href ng_src ng_srcset ng_disabled ng_checked ng_readonly 
+         ng_selected ng_open ng_form ng_value ng_bind ng_bind_template ng_bind_html 
+         ng_change ng_class ng_class_odd ng_class_even ng_cloak ng_controller ng_csp 
+         ng_click ng_dblclick ng_mousedown ng_mouseup ng_mouseover ng_mouseenter 
+         ng_mouseleave ng_mousemove ng_keydown ng_keyup ng_keypress ng_submit ng_focus
+         ng_blur ng_copy ng_cut ng_paste ng_if ng_include ng_init ng_list ng_model 
+         ng_model_options ng_non_bindable ng_options ng_pluralize ng_repeat ng_show 
+         ng_hide ng_style ng_switch ng_transclude)
+    end
+
+    def add directives
+      directives.tap do |array|
+        array.each { |custom| Watir::HTMLElement.attributes << custom }
+      end
+    end
+  end
+end

--- a/spec/watir-ng/directives_spec.rb
+++ b/spec/watir-ng/directives_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe WatirNg::Directives do
+  describe "#ng" do
+    it "returns an array" do
+      expect(subject.ng).to be_an Array
+    end
+  end
+  
+  describe "#add_custom" do
+    let(:base_class){ double "class" }
+
+    it "returns an array of its arguments" do
+      allow(Watir::HTMLElement).to receive(:attributes).and_return []
+      expect(subject.add [:foo, :bar]).to eq [:foo, :bar]
+    end
+
+    it "patches custom directives onto Watir::HTMLElement" do
+      attributes = double "[]"
+      expect(Watir::HTMLElement).to receive(:attributes).twice.and_return attributes
+      expect(attributes).to receive(:<<).with(:foo)
+      expect(attributes).to receive(:<<).with(:bar)
+      subject.add [:foo, :bar]
+    end
+  end
+end

--- a/spec/watir_ng_spec.rb
+++ b/spec/watir_ng_spec.rb
@@ -1,35 +1,49 @@
 require 'spec_helper'
 
 describe WatirNg do
-  let(:directives){ WatirNg::NG_STRINGS.map(&:to_sym) }
-  
   it 'has a version number' do
     expect(WatirNg::VERSION).not_to be nil
   end
 
-  describe "#custom_directives" do
-    it "returns an array" do
-      expect(WatirNg.custom_directives).to eq []
+  describe ".directives" do
+    it "returns a Directives object" do
+      expect(WatirNg.directives).to be_a WatirNg::Directives
+    end
+
+    it "memoizes the Directives object" do
+      expect(WatirNg.directives).to eq WatirNg.directives
     end
   end
 
   context "when included on a class" do
-    it "adds each ng directive to class.attributes" do
+    let(:ng){ WatirNg::Directives.new.ng }
+    
+    it "patches ng directives onto Class.attributes" do
       TestClass.send(:include, WatirNg)
-      expect(TestClass.attributes).to eq directives
+      expect(TestClass.attributes).to eq ng
     end
 
-    it "does not overwrite the class.attributes" do
+    it "does not overwrite the Class.attributes" do
       TestClass.attributes = [:foo]
       TestClass.send(:include, WatirNg)
       expect(TestClass.attributes).to include(:foo)
-      expect(TestClass.attributes).to include(*directives)
+      expect(TestClass.attributes).to include(*ng)
+    end
+  end
+
+  describe ".register" do
+    let(:dir_obj){ double "WatirNg::Directives"}
+    before do
+      expect(subject).to receive(:directives).and_return dir_obj
+      expect(dir_obj).to receive(:add).with [:foobar, :foobaz]
+    end
+    
+    it "passes custom attributes on as an array" do
+      subject.register :foobar, :foobaz
     end
 
-    it "includes custom directives when configured" do
-      WatirNg.custom_directives << :ng_foo_bar
-      TestClass.send(:include, WatirNg)
-      expect(TestClass.attributes).to include(:ng_foo_bar)
+    it "maps its arguments to symbols" do
+      subject.register "foobar", "foobaz"
     end
   end
 end

--- a/spec/watir_ng_spec.rb
+++ b/spec/watir_ng_spec.rb
@@ -20,14 +20,14 @@ describe WatirNg do
     
     it "patches ng directives onto Class.attributes" do
       TestClass.send(:include, WatirNg)
-      expect(TestClass.attributes).to eq ng
+      expect(TestClass.attributes).to eq ng.map(&:to_sym)
     end
 
     it "does not overwrite the Class.attributes" do
       TestClass.attributes = [:foo]
       TestClass.send(:include, WatirNg)
       expect(TestClass.attributes).to include(:foo)
-      expect(TestClass.attributes).to include(*ng)
+      expect(TestClass.attributes).to include(*ng.map(&:to_sym))
     end
   end
 


### PR DESCRIPTION
## Changes
- Abstract ng and custom directives to their own collection object
- `WatirNg::Directives#add` patches `Watir::HTMLElement` with its arguments
- Changes API for custom identifiers from `WatirNg.custom_directives` to `WatirNg.register` and no longer requires you to push arguments onto the API. Example:

``` ruby
# old 
WatirNg.custom_directives << :ng_foo_bar

# new
WatirNg.register :ng_foo_bar
```

Need to bump to version 1.2.0.
