### PR TITLE
Deprecated require "watir-webdriver" in favor of require "watir" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.1.0
+- Removed the deprecated calls for `require 'watir-webdriver`. As of watir 6.0 this is now deprecated.
+- As of this version Ruby 1.9.3 is not compatible with watir-ng.
+
 ## v2.0.0 (Feb 24 2016)
 - Patch browser objects with `WatirNg.patch!`
 - Add custom directive identifiers with `WatirNg.register`

--- a/lib/watir-ng.rb
+++ b/lib/watir-ng.rb
@@ -1,5 +1,5 @@
-require "watir-webdriver"
-require "watir-ng/version"
+require 'watir'
+require 'watir-ng/version'
 
 #
 # Adds AngularJS `ng` directives as identifiers for `Watir::Webdriver` elements.

--- a/lib/watir-ng/version.rb
+++ b/lib/watir-ng/version.rb
@@ -1,4 +1,4 @@
 module WatirNg
   # :nodoc:
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/watir-ng/version.rb
+++ b/lib/watir-ng/version.rb
@@ -1,4 +1,4 @@
 module WatirNg
   # :nodoc:
-  VERSION = "2.0.1"
+  VERSION = '2.1.0'
 end

--- a/watir-ng.gemspec
+++ b/watir-ng.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "watir-webdriver", ">= 0.7.0"
+  spec.add_runtime_dependency 'watir', '~> 6.0.0'
   
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This PR addresses issues when using latest version of Watir. Currently` require 'watir-ng' ` and `require 'watir'` cannot be used together. As of Watir 6.0 `require 'watir-webdriver'  is deprecated. 