### PR TITLE
Gem updates for Watir, RSpec & Cucumber

### DIFF
--- a/watir-ng.gemspec
+++ b/watir-ng.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "cucumber", "~> 2.0"
 end

--- a/watir-ng.gemspec
+++ b/watir-ng.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'watir', '~> 6.0.0'
+  spec.add_runtime_dependency 'watir', '~> 6.0'
   
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.2.0"
-  spec.add_development_dependency "cucumber", "~> 2.0.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "cucumber", "~> 2.0"
 end


### PR DESCRIPTION
Relax the gem version constraint to allow for newer watir versions. Update rspec and cucumber versions to prevent a couple of feature test errors.